### PR TITLE
Add room UI and secure admin page

### DIFF
--- a/app/admin/AdminClient.tsx
+++ b/app/admin/AdminClient.tsx
@@ -1,0 +1,57 @@
+'use client';
+import useSWR from 'swr'
+import { useRouter } from 'next/navigation'
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+
+const fetcher = (url: string) => fetch(url).then(res => res.json());
+
+export default function AdminClient() {
+  const router = useRouter();
+  const { data, mutate } = useSWR('/api/bookings', fetcher);
+
+  const createRoom = async (id: string) => {
+    const res = await fetch('/api/create-room', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ id })
+    });
+    const { url } = await res.json();
+    mutate();
+    router.push(`/room?url=${encodeURIComponent(url)}`);
+  };
+
+  if (!data) return <p>Loading...</p>
+
+  return (
+    <main className="container mx-auto p-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Bookings</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {data.map((b: any) => (
+            <Card key={b.id} className="border p-4">
+              <div className="font-medium">
+                {b.date} {b.time}
+              </div>
+              <div className="text-sm text-muted-foreground mb-2">{b.notes}</div>
+              {!b.roomUrl ? (
+                <Button size="sm" onClick={() => createRoom(b.id)}>
+                  Create Room
+                </Button>
+              ) : (
+                <Button
+                  size="sm"
+                  onClick={() => router.push(`/room?url=${encodeURIComponent(b.roomUrl)}`)}
+                >
+                  Open Room
+                </Button>
+              )}
+            </Card>
+          ))}
+        </CardContent>
+      </Card>
+    </main>
+  )
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,50 +1,11 @@
-'use client';
-import useSWR from 'swr'
-import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
-import { Button } from '@/components/ui/button'
-
-const fetcher = (url: string) => fetch(url).then(res => res.json());
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import AdminClient from './AdminClient';
 
 export default function AdminPage() {
-  const { data, mutate } = useSWR('/api/bookings', fetcher);
-
-  const createRoom = async (id: string) => {
-    const res = await fetch('/api/create-room', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ id })
-    });
-    const { url } = await res.json();
-    alert(`Room created: ${url}`);
-    mutate();
-  };
-
-  if (!data) return <p>Loading...</p>
-
-  return (
-    <main className="container mx-auto p-4">
-      <Card>
-        <CardHeader>
-          <CardTitle>Bookings</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          {data.map((b: any) => (
-            <Card key={b.id} className="border p-4">
-              <div className="font-medium">
-                {b.date} {b.time}
-              </div>
-              <div className="text-sm text-muted-foreground mb-2">{b.notes}</div>
-              {!b.roomUrl ? (
-                <Button size="sm" onClick={() => createRoom(b.id)}>
-                  Create Room
-                </Button>
-              ) : (
-                <div className="text-sm break-all">Room: {b.roomUrl}</div>
-              )}
-            </Card>
-          ))}
-        </CardContent>
-      </Card>
-    </main>
-  )
+  const cookie = cookies().get('auth');
+  if (!cookie) {
+    redirect('/login');
+  }
+  return <AdminClient />;
 }

--- a/app/room/page.tsx
+++ b/app/room/page.tsx
@@ -1,0 +1,26 @@
+'use client';
+import { useSearchParams } from 'next/navigation';
+import { Button } from '@/components/ui/button';
+
+export default function RoomPage() {
+  const params = useSearchParams();
+  const url = params.get('url');
+
+  if (!url) return <p className="p-4">No room URL provided.</p>;
+
+  const copyLink = async () => {
+    await navigator.clipboard.writeText(url);
+    alert('Link copied to clipboard');
+  };
+
+  return (
+    <main className="container mx-auto p-4 space-y-4">
+      <Button onClick={copyLink}>Copy Link</Button>
+      <iframe
+        src={url}
+        className="w-full h-[80vh] border"
+        allow="camera; microphone"
+      />
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add a page to display a Twilio room and allow copying the link
- redirect admin to the room page when a room is created
- open existing rooms from the admin page
- protect `/admin` with a cookie check

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684c172306a483309684aa947307ea21