### PR TITLE
Fix useSearchParams warning for room page

### DIFF
--- a/app/room/page.tsx
+++ b/app/room/page.tsx
@@ -1,8 +1,9 @@
 'use client';
+import { Suspense } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 
-export default function RoomPage() {
+function RoomContent() {
   const params = useSearchParams();
   const url = params.get('url');
 
@@ -22,5 +23,13 @@ export default function RoomPage() {
         allow="camera; microphone"
       />
     </main>
+  );
+}
+
+export default function RoomPage() {
+  return (
+    <Suspense>
+      <RoomContent />
+    </Suspense>
   );
 }


### PR DESCRIPTION
## Summary
- wrap room page search params usage in `<Suspense>` to satisfy Next.js requirements

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c19758e908330a5e7c6fb947591cc