### PR TITLE
Improve time handling for bookings and rooms

### DIFF
--- a/app/admin/AdminClient.tsx
+++ b/app/admin/AdminClient.tsx
@@ -16,8 +16,12 @@ export default function AdminClient() {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ id })
     });
-    const { url } = await res.json();
+    const { url, error } = await res.json();
     mutate();
+    if (!res.ok || !url) {
+      alert(error || 'Failed to create room');
+      return;
+    }
     router.push(`/room?url=${encodeURIComponent(url)}`);
   };
 
@@ -37,7 +41,16 @@ export default function AdminClient() {
               </div>
               <div className="text-sm text-muted-foreground mb-2">{b.notes}</div>
               {!b.roomUrl ? (
-                <Button size="sm" onClick={() => createRoom(b.id)}>
+                <Button
+                  size="sm"
+                  onClick={() => createRoom(b.id)}
+                  variant={
+                    new Date(`${b.date}T${b.time}:00Z`).getTime() - Date.now() >
+                    15 * 60 * 1000
+                      ? 'secondary'
+                      : 'default'
+                  }
+                >
                   Create Room
                 </Button>
               ) : (

--- a/app/api/bookings/route.ts
+++ b/app/api/bookings/route.ts
@@ -9,7 +9,13 @@ export async function GET() {
 
 export async function POST(req: NextRequest) {
   const { date, time, notes } = await req.json();
-  const booking: Booking = { id: randomUUID(), date, time, notes };
+  const iso = new Date(`${date}T${time}Z`).toISOString();
+  const booking: Booking = {
+    id: randomUUID(),
+    date: iso.slice(0, 10),
+    time: iso.slice(11, 16),
+    notes,
+  };
   await createBooking(booking);
   return NextResponse.json(booking);
 }

--- a/app/api/create-room/route.ts
+++ b/app/api/create-room/route.ts
@@ -11,10 +11,6 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ url: booking.roomUrl });
   }
 
-  const bookingTime = new Date(`${booking.date}T${booking.time}:00`);
-  if (bookingTime.getTime() - Date.now() > 15 * 60 * 1000) {
-    return NextResponse.json({ error: 'Too early' }, { status: 400 });
-  }
 
   if (!process.env.TWILIO_SID || !process.env.TWILIO_TOKEN) {
     return NextResponse.json({ error: 'Server misconfigured' }, { status: 500 });
@@ -34,7 +30,9 @@ export async function POST(req: NextRequest) {
     const roomUrl = room.url;
     await setRoomUrl(id, roomUrl);
     return NextResponse.json({ url: roomUrl });
-  } catch (err) {
-    return NextResponse.json({ error: 'Failed to create room' }, { status: 500 });
+  } catch (err: any) {
+    console.error('Twilio create room failed', err);
+    const message = err && typeof err === 'object' && 'message' in err ? err.message : 'Failed to create room';
+    return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/test/create-room.test.ts
+++ b/test/create-room.test.ts
@@ -24,11 +24,12 @@ describe('create-room API', () => {
     assert.equal(res.status, 404);
   });
 
-  it('rejects creating too early', async () => {
+  it('creates room even if too early', async () => {
     bookings.push({ id: '2', date: '2099-01-01', time: '10:00', notes: 'n' });
     const req = new NextRequest('http://test', { body: JSON.stringify({ id: '2' }) });
     const res: any = await POST(req);
-    assert.equal(res.status, 400);
+    assert.equal(res.status, 200);
+    assert.equal(res.data.url, 'https://video.twilio.com/v1/Rooms/RM_TEST');
   });
 
   it('returns existing room url', async () => {

--- a/test/setup.js
+++ b/test/setup.js
@@ -14,3 +14,4 @@ Module._resolveFilename = function(request, parent, isMain, options) {
 process.env.NODE_ENV = 'test';
 process.env.TWILIO_SID = 'test';
 process.env.TWILIO_TOKEN = 'test';
+process.env.TZ = 'UTC';


### PR DESCRIPTION
## Summary
- store booking dates and times in UTC
- allow admins to create rooms early and grey out the button when early
- adjust tests for new behavior
- surface Twilio error messages when room creation fails

## Testing
- `pnpm install`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684c1deda4008330987e662bc44c08cc