### PR TITLE
Add blockout management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Reflect Therapy
 
-This is a template Next.js site for online therapy sessions. It includes a simple booking form, admin page to manage bookings, and Twilio integration for video calls. Deploy using [SST](https://sst.dev) to AWS.
+This is a template Next.js site for online therapy sessions. It includes a simple booking form, admin page to manage bookings, cancel appointments, block out times, and Twilio integration for video calls. Deploy using [SST](https://sst.dev) to AWS.
 
 ## Setup
 
@@ -33,6 +33,7 @@ TWILIO_AUTH_TOKEN=your_twilio_auth_token
 TWILIO_API_KEY=your_api_key_sid
 TWILIO_API_SECRET=your_api_key_secret
 BOOKINGS_TABLE_NAME=name_of_dynamodb_table
+BLOCKOUTS_TABLE_NAME=name_of_blockouts_table
 ```
 
 When deploying via GitHub Actions, include the same variables as repository secrets so the site can access them in production.

--- a/app/admin/AdminClient.tsx
+++ b/app/admin/AdminClient.tsx
@@ -3,12 +3,14 @@ import useSWR from 'swr'
 import { useRouter } from 'next/navigation'
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
+import type { FormEvent } from 'react'
 
 const fetcher = (url: string) => fetch(url).then(res => res.json());
 
 export default function AdminClient() {
   const router = useRouter();
   const { data, mutate } = useSWR('/api/bookings', fetcher);
+  const { data: blocks, mutate: mutateBlocks } = useSWR('/api/blockouts', fetcher);
 
   const createRoom = async (id: string) => {
     const res = await fetch('/api/create-room', {
@@ -25,7 +27,34 @@ export default function AdminClient() {
     router.push(`/room?url=${encodeURIComponent(url)}`);
   };
 
-  if (!data) return <p>Loading...</p>
+  const cancelBooking = async (id: string) => {
+    await fetch(`/api/bookings/${id}`, { method: 'DELETE' });
+    mutate();
+  };
+
+  const addBlockout = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const form = e.currentTarget as HTMLFormElement;
+    const formData = new FormData(form);
+    await fetch('/api/blockouts', {
+      method: 'POST',
+      body: JSON.stringify({
+        date: formData.get('date'),
+        time: formData.get('time'),
+        reason: formData.get('reason'),
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+    form.reset();
+    mutateBlocks();
+  };
+
+  const deleteBlock = async (id: string) => {
+    await fetch(`/api/blockouts/${id}`, { method: 'DELETE' });
+    mutateBlocks();
+  };
+
+  if (!data || !blocks) return <p>Loading...</p>
 
   return (
     <main className="container mx-auto p-4">
@@ -35,34 +64,67 @@ export default function AdminClient() {
         </CardHeader>
         <CardContent className="space-y-4">
           {data.map((b: any) => (
-            <Card key={b.id} className="border p-4">
+            <Card key={b.id} className="border p-4 space-y-2">
               <div className="font-medium">
                 {b.date} {b.time}
               </div>
-              <div className="text-sm text-muted-foreground mb-2">{b.notes}</div>
-              {!b.roomUrl ? (
-                <Button
-                  size="sm"
-                  onClick={() => createRoom(b.id)}
-                  variant={
-                    new Date(`${b.date}T${b.time}:00Z`).getTime() - Date.now() >
-                    15 * 60 * 1000
-                      ? 'secondary'
-                      : 'default'
-                  }
-                >
-                  Create Room
-                </Button>
+              <div className="text-sm text-muted-foreground">{b.notes}</div>
+              {b.status === 'cancelled' ? (
+                <div className="text-sm text-red-500">Cancelled</div>
               ) : (
-                <Button
-                  size="sm"
-                  onClick={() => router.push(`/room?url=${encodeURIComponent(b.roomUrl)}`)}
-                >
-                  Open Room
-                </Button>
+                <div className="flex gap-2">
+                  {!b.roomUrl ? (
+                    <Button
+                      size="sm"
+                      onClick={() => createRoom(b.id)}
+                      variant={
+                        new Date(`${b.date}T${b.time}:00Z`).getTime() - Date.now() >
+                        15 * 60 * 1000
+                          ? 'secondary'
+                          : 'default'
+                      }
+                    >
+                      Create Room
+                    </Button>
+                  ) : (
+                    <Button
+                      size="sm"
+                      onClick={() => router.push(`/room?url=${encodeURIComponent(b.roomUrl)}`)}
+                    >
+                      Open Room
+                    </Button>
+                  )}
+                  <Button size="sm" variant="destructive" onClick={() => cancelBooking(b.id)}>
+                    Cancel
+                  </Button>
+                </div>
               )}
             </Card>
           ))}
+        </CardContent>
+      </Card>
+
+      <Card className="mt-8">
+        <CardHeader>
+          <CardTitle>Blocked Times</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {blocks.map((b: any) => (
+            <Card key={b.id} className="border p-4 flex justify-between">
+              <div>
+                {b.date} {b.time} {b.reason && `- ${b.reason}`}
+              </div>
+              <Button size="sm" variant="destructive" onClick={() => deleteBlock(b.id)}>
+                Remove
+              </Button>
+            </Card>
+          ))}
+          <form onSubmit={addBlockout} className="space-y-2">
+            <input type="date" name="date" required className="border p-1" />
+            <input type="time" name="time" required className="border p-1" />
+            <input type="text" name="reason" placeholder="Reason" className="border p-1" />
+            <Button type="submit" size="sm" className="ml-2">Add</Button>
+          </form>
         </CardContent>
       </Card>
     </main>

--- a/app/api/blockouts/[id]/route.ts
+++ b/app/api/blockouts/[id]/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+import { deleteBlockout } from '../../../../lib/data';
+
+export async function DELETE(_: Request, { params }: { params: { id: string } }) {
+  await deleteBlockout(params.id);
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/blockouts/route.ts
+++ b/app/api/blockouts/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { listBlockouts, createBlockout, Blockout } from '../../../lib/data';
+import { randomUUID } from 'crypto';
+
+export async function GET() {
+  const items = await listBlockouts();
+  return NextResponse.json(items);
+}
+
+export async function POST(req: NextRequest) {
+  const { date, time, reason } = await req.json();
+  const blockout: Blockout = {
+    id: randomUUID(),
+    date,
+    time,
+    reason,
+  };
+  await createBlockout(blockout);
+  return NextResponse.json(blockout);
+}

--- a/app/api/bookings/[id]/route.ts
+++ b/app/api/bookings/[id]/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+import { cancelBooking } from '../../../../lib/data';
+
+export async function DELETE(_: Request, { params }: { params: { id: string } }) {
+  await cancelBooking(params.id);
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/bookings/route.ts
+++ b/app/api/bookings/route.ts
@@ -8,13 +8,17 @@ export async function GET() {
 }
 
 export async function POST(req: NextRequest) {
-  const { date, time, notes } = await req.json();
+  const { date, time, name, email, phone, notes } = await req.json();
   const iso = new Date(`${date}T${time}Z`).toISOString();
   const booking: Booking = {
     id: randomUUID(),
     date: iso.slice(0, 10),
     time: iso.slice(11, 16),
+    name,
+    email,
+    phone,
     notes,
+    status: 'booked',
   };
   await createBooking(booking);
   return NextResponse.json(booking);

--- a/app/booking/page.tsx
+++ b/app/booking/page.tsx
@@ -9,6 +9,9 @@ import { Label } from '@/components/ui/label'
 export default function BookingPage() {
   const [date, setDate] = useState('');
   const [time, setTime] = useState('');
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
   const [notes, setNotes] = useState('');
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -16,7 +19,7 @@ export default function BookingPage() {
     await fetch('/api/bookings', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ date, time, notes })
+      body: JSON.stringify({ date, time, name, email, phone, notes })
     });
     alert('Booking requested');
   };
@@ -29,6 +32,33 @@ export default function BookingPage() {
         </CardHeader>
         <form onSubmit={handleSubmit} className="space-y-4">
           <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="name">Name</Label>
+              <Input
+                id="name"
+                value={name}
+                onChange={e => setName(e.target.value)}
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="email">Email</Label>
+              <Input
+                id="email"
+                type="email"
+                value={email}
+                onChange={e => setEmail(e.target.value)}
+                required
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="phone">Phone (optional)</Label>
+              <Input
+                id="phone"
+                value={phone}
+                onChange={e => setPhone(e.target.value)}
+              />
+            </div>
             <div className="space-y-2">
               <Label htmlFor="date">Date</Label>
               <Input

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,13 @@ export default function HomePage() {
       <p>
         Reflect Therapy provides compassionate, professional therapy services.
       </p>
+      <p className="mt-4">
+        Contact us at <a href="mailto:info@reflect.example" className="underline text-blue-700">info@reflect.example</a>
+        {' '}or call <a href="tel:+123456789">+1&nbsp;234&nbsp;567&nbsp;89</a>.
+      </p>
+      <p className="mt-4">
+        <a href="/booking" className="text-blue-700 underline">Book a session</a>
+      </p>
     </main>
   );
 }

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -5,21 +5,36 @@ import {
   GetCommand,
   PutCommand,
   UpdateCommand,
+  DeleteCommand,
 } from '@aws-sdk/lib-dynamodb';
 
 export interface Booking {
   id: string;
   date: string;
   time: string;
+  name: string;
+  email: string;
+  phone?: string;
   notes: string;
   roomUrl?: string;
+  status?: 'booked' | 'cancelled';
+}
+
+export interface Blockout {
+  id: string;
+  date: string;
+  time: string;
+  reason?: string;
 }
 
 // In-memory store used when running tests or if the table isn't configured
 export const bookings: Booking[] = [];
+export const blockouts: Blockout[] = [];
 
 const TABLE = process.env.BOOKINGS_TABLE_NAME;
+const BLOCKOUT_TABLE = process.env.BLOCKOUTS_TABLE_NAME;
 const useMemory = !TABLE || process.env.NODE_ENV === 'test';
+const blockoutMemory = !BLOCKOUT_TABLE || process.env.NODE_ENV === 'test';
 
 let client: DynamoDBDocumentClient | undefined;
 if (!useMemory) {
@@ -58,6 +73,51 @@ export async function setRoomUrl(id: string, roomUrl: string): Promise<void> {
       Key: { id },
       UpdateExpression: 'SET roomUrl = :url',
       ExpressionAttributeValues: { ':url': roomUrl },
+    })
+  );
+}
+
+export async function cancelBooking(id: string): Promise<void> {
+  if (useMemory) {
+    const booking = bookings.find((b) => b.id === id);
+    if (booking) booking.status = 'cancelled';
+    return;
+  }
+  await client!.send(
+    new UpdateCommand({
+      TableName: TABLE,
+      Key: { id },
+      UpdateExpression: 'SET #st = :s',
+      ExpressionAttributeNames: { '#st': 'status' },
+      ExpressionAttributeValues: { ':s': 'cancelled' },
+    })
+  );
+}
+
+export async function listBlockouts(): Promise<Blockout[]> {
+  if (blockoutMemory) return blockouts;
+  const res = await client!.send(new ScanCommand({ TableName: BLOCKOUT_TABLE }));
+  return (res.Items || []) as Blockout[];
+}
+
+export async function createBlockout(b: Blockout): Promise<void> {
+  if (blockoutMemory) {
+    blockouts.push(b);
+    return;
+  }
+  await client!.send(new PutCommand({ TableName: BLOCKOUT_TABLE, Item: b }));
+}
+
+export async function deleteBlockout(id: string): Promise<void> {
+  if (blockoutMemory) {
+    const idx = blockouts.findIndex((b) => b.id === id);
+    if (idx !== -1) blockouts.splice(idx, 1);
+    return;
+  }
+  await client!.send(
+    new DeleteCommand({
+      TableName: BLOCKOUT_TABLE,
+      Key: { id },
     })
   );
 }

--- a/stacks/MyStack.ts
+++ b/stacks/MyStack.ts
@@ -8,15 +8,23 @@ export function MyStack({ stack }: StackContext) {
     primaryIndex: { partitionKey: 'id' },
   });
 
+  const blockouts = new Table(stack, 'Blockouts', {
+    fields: {
+      id: 'string',
+    },
+    primaryIndex: { partitionKey: 'id' },
+  });
+
   const site = new NextjsSite(stack, 'Site', {
     path: '.',
-    bind: [table],
+    bind: [table, blockouts],
     environment: {
       ADMIN_PASSWORD: process.env.ADMIN_PASSWORD!,
       TWILIO_ACCOUNT_SID: process.env.TWILIO_ACCOUNT_SID!,
       TWILIO_AUTH_TOKEN: process.env.TWILIO_AUTH_TOKEN!,
       TWILIO_API_KEY: process.env.TWILIO_API_KEY!,
       TWILIO_API_SECRET: process.env.TWILIO_API_SECRET!,
+      BLOCKOUTS_TABLE_NAME: blockouts.tableName,
     },
   });
 

--- a/test/blockouts.test.ts
+++ b/test/blockouts.test.ts
@@ -1,0 +1,30 @@
+import { strict as assert } from 'assert';
+import { blockouts } from '../lib/data';
+import { GET, POST } from '../app/api/blockouts/route';
+import { DELETE } from '../app/api/blockouts/[id]/route';
+import { NextRequest } from 'next/server';
+
+describe('blockouts API', () => {
+  beforeEach(() => { blockouts.length = 0; });
+
+  it('creates a blockout', async () => {
+    const req = new NextRequest('http://test', { body: JSON.stringify({ date: '2025-01-01', time: '10:00', reason: 'busy' }) });
+    const res: any = await POST(req);
+    assert.equal(res.status, 200);
+    assert.equal(blockouts.length, 1);
+  });
+
+  it('lists blockouts', async () => {
+    blockouts.push({ id: '1', date: 'd', time: 't' });
+    const res: any = await GET();
+    assert.deepEqual(res.data, blockouts);
+  });
+
+  it('deletes a blockout', async () => {
+    blockouts.push({ id: '2', date: 'd', time: 't' });
+    const req = new NextRequest('http://test');
+    const res: any = await DELETE(req, { params: { id: '2' } });
+    assert.equal(res.status, 200);
+    assert.equal(blockouts.length, 0);
+  });
+});

--- a/test/bookings.test.ts
+++ b/test/bookings.test.ts
@@ -7,7 +7,7 @@ describe('bookings API', () => {
   beforeEach(() => { bookings.length = 0; });
 
   it('creates a booking', async () => {
-    const req = new NextRequest('http://test', { body: JSON.stringify({ date: '2025-01-01', time: '10:00', notes: 'hi' }) });
+    const req = new NextRequest('http://test', { body: JSON.stringify({ date: '2025-01-01', time: '10:00', name: 'A', email: 'a@b.com', notes: 'hi' }) });
     const res: any = await POST(req);
     assert.equal(res.status, 200);
     assert.equal(bookings.length, 1);
@@ -15,7 +15,7 @@ describe('bookings API', () => {
   });
 
   it('lists bookings', async () => {
-    bookings.push({ id: '1', date: 'd', time: 't', notes: 'n' });
+    bookings.push({ id: '1', date: 'd', time: 't', name: 'A', email: 'a', notes: 'n' });
     const res: any = await GET();
     assert.deepEqual(res.data, bookings);
   });

--- a/test/cancel.test.ts
+++ b/test/cancel.test.ts
@@ -1,0 +1,16 @@
+import { strict as assert } from 'assert';
+import { bookings } from '../lib/data';
+import { DELETE } from '../app/api/bookings/[id]/route';
+import { NextRequest } from 'next/server';
+
+describe('cancel booking API', () => {
+  beforeEach(() => { bookings.length = 0; });
+
+  it('marks booking as cancelled', async () => {
+    bookings.push({ id: '1', date: 'd', time: 't', name: 'A', email: 'a', notes: 'n', status: 'booked' });
+    const req = new NextRequest('http://test');
+    const res: any = await DELETE(req, { params: { id: '1' } });
+    assert.equal(res.status, 200);
+    assert.equal(bookings[0].status, 'cancelled');
+  });
+});

--- a/test/create-room.test.ts
+++ b/test/create-room.test.ts
@@ -11,7 +11,7 @@ describe('create-room API', () => {
 
   it('creates room for booking', async () => {
     const now = new Date(Date.now() + 5 * 60 * 1000);
-    bookings.push({ id: '1', date: now.toISOString().slice(0,10), time: now.toISOString().slice(11,16), notes: 'n' });
+    bookings.push({ id: '1', date: now.toISOString().slice(0,10), time: now.toISOString().slice(11,16), name: 'A', email: 'a', notes: 'n' });
     const req = new NextRequest('http://test', { body: JSON.stringify({ id: '1' }) });
     const res: any = await POST(req);
     assert.equal(res.status, 200);
@@ -28,7 +28,7 @@ describe('create-room API', () => {
   });
 
   it('creates room even if too early', async () => {
-    bookings.push({ id: '2', date: '2099-01-01', time: '10:00', notes: 'n' });
+    bookings.push({ id: '2', date: '2099-01-01', time: '10:00', name: 'B', email: 'b', notes: 'n' });
     const req = new NextRequest('http://test', { body: JSON.stringify({ id: '2' }) });
     const res: any = await POST(req);
     assert.equal(res.status, 200);
@@ -40,7 +40,7 @@ describe('create-room API', () => {
 
   it('returns existing room url', async () => {
     const now = new Date();
-    bookings.push({ id: '3', date: now.toISOString().slice(0,10), time: now.toISOString().slice(11,16), notes: 'n', roomUrl: 'foo' });
+    bookings.push({ id: '3', date: now.toISOString().slice(0,10), time: now.toISOString().slice(11,16), name: 'C', email: 'c', notes: 'n', roomUrl: 'foo' });
     const req = new NextRequest('http://test', { body: JSON.stringify({ id: '3' }) });
     const res: any = await POST(req);
     assert.equal(res.status, 200);


### PR DESCRIPTION
## Summary
- add ability to block out unavailable times
- store client details when booking
- show contact info and booking CTA on home page
- update admin dashboard to manage blockouts
- expand tests for new APIs

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c2dd8f714833091bccd200a1b13b9