### PR TITLE
Fix video tile binding for null id

### DIFF
--- a/app/room/page.tsx
+++ b/app/room/page.tsx
@@ -35,7 +35,8 @@ function RoomContent() {
       videoTileDidUpdate: (tile) => {
         if (!tile.boundAttendeeId) return;
         const el = tile.localTile ? localVideoRef.current : remoteVideoRef.current;
-        if (el) meetingSession.audioVideo.bindVideoElement(tile.tileId, el);
+        if (el && tile.tileId != null)
+          meetingSession.audioVideo.bindVideoElement(tile.tileId, el);
       },
     });
 


### PR DESCRIPTION
## Summary
- handle null tile ID when binding to video element

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cf22e53a08330bcc8e7e12d4ce0df