### PR TITLE
Fix circular dependency in SST stack

### DIFF
--- a/app/api/send-link/route.ts
+++ b/app/api/send-link/route.ts
@@ -13,12 +13,13 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Not found' }, { status: 404 });
   }
   try {
+    const baseUrl = process.env.SITE_URL || req.nextUrl.origin;
     if (booking.email) {
       await ses.send(
         new SendEmailCommand({
           Destination: { ToAddresses: [booking.email] },
           Message: {
-            Body: { Text: { Data: `Join your session at ${process.env.SITE_URL}${booking.roomUrl}` } },
+            Body: { Text: { Data: `Join your session at ${baseUrl}${booking.roomUrl}` } },
             Subject: { Data: 'Your session link' },
           },
           Source: process.env.EMAIL_FROM!,
@@ -29,7 +30,7 @@ export async function POST(req: NextRequest) {
       await sns.send(
         new PublishCommand({
           PhoneNumber: booking.phone,
-          Message: `Join your session at ${process.env.SITE_URL}${booking.roomUrl}`,
+          Message: `Join your session at ${baseUrl}${booking.roomUrl}`,
         })
       );
     }

--- a/stacks/MyStack.ts
+++ b/stacks/MyStack.ts
@@ -25,8 +25,6 @@ export function MyStack({ stack }: StackContext) {
       EMAIL_FROM: process.env.EMAIL_FROM!,
     },
   });
-  const siteFunc = site.cdk?.function as unknown as lambda.Function | undefined;
-  siteFunc?.addEnvironment('SITE_URL', site.url || '');
 
   stack.addOutputs({
     SiteUrl: site.url,


### PR DESCRIPTION
## Summary
- remove environment var injection for site URL
- build dynamic site URL in send-link route instead

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684cfb776d148330a509592f1c0a5774