### PR TITLE
Fix Chime permission

### DIFF
--- a/stacks/MyStack.ts
+++ b/stacks/MyStack.ts
@@ -26,6 +26,9 @@ export function MyStack({ stack }: StackContext) {
     },
   });
 
+  // Allow the site to create Amazon Chime meetings
+  site.attachPermissions(["chime:*"]);
+
   stack.addOutputs({
     SiteUrl: site.url,
   });


### PR DESCRIPTION
## Summary
- allow Chime meeting creation via stack permissions

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684cfe45eb4883308798a766af2552a4