### PR TITLE
Fix send-link permissions

### DIFF
--- a/stacks/MyStack.ts
+++ b/stacks/MyStack.ts
@@ -27,8 +27,12 @@ export function MyStack({ stack }: StackContext) {
     },
   });
 
-  // Allow the site to create Amazon Chime meetings
-  site.attachPermissions(["chime:*"]);
+  // Allow the site to create Amazon Chime meetings and send emails/SMS
+  site.attachPermissions([
+    "chime:*",
+    "ses:SendEmail",
+    "sns:Publish",
+  ]);
 
   stack.addOutputs({
     SiteUrl: site.url,


### PR DESCRIPTION
## Summary
- attach `ses:SendEmail` and `sns:Publish` permissions so the app can send email and SMS links

## Testing
- `pnpm install`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_684d21b698a48330ab57e0857336e175