### PR TITLE
Add admin/client meeting links

### DIFF
--- a/app/admin/AdminClient.tsx
+++ b/app/admin/AdminClient.tsx
@@ -18,13 +18,13 @@ export default function AdminClient() {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ id })
     });
-    const { url, error } = await res.json();
+    const { adminUrl, error } = await res.json();
     mutate();
-    if (!res.ok || !url) {
+    if (!res.ok || !adminUrl) {
       alert(error || 'Failed to create room');
       return;
     }
-    router.push(url);
+    router.push(adminUrl);
   };
 
   const sendLink = async (id: string) => {
@@ -87,13 +87,13 @@ export default function AdminClient() {
                 <div className="text-sm text-red-500">Cancelled</div>
               ) : (
                 <div className="flex gap-2">
-                  {!b.roomUrl ? (
+                  {!b.adminUrl ? (
                     <Button
                       size="sm"
                       onClick={() => createRoom(b.id)}
                       variant={
                         new Date(`${b.date}T${b.time}:00Z`).getTime() - Date.now() >
-                        15 * 60 * 1000
+                          15 * 60 * 1000
                           ? 'secondary'
                           : 'default'
                       }
@@ -104,7 +104,7 @@ export default function AdminClient() {
                     <>
                       <Button
                         size="sm"
-                        onClick={() => router.push(b.roomUrl)}
+                        onClick={() => router.push(b.adminUrl)}
                       >
                         Open Room
                       </Button>

--- a/app/api/send-link/route.ts
+++ b/app/api/send-link/route.ts
@@ -9,7 +9,7 @@ const sns = new SNSClient({});
 export async function POST(req: NextRequest) {
   const { id } = await req.json();
   const booking = await getBooking(id);
-  if (!booking || !booking.roomUrl) {
+  if (!booking || !booking.clientUrl) {
     return NextResponse.json({ error: 'Not found' }, { status: 404 });
   }
   try {
@@ -19,7 +19,7 @@ export async function POST(req: NextRequest) {
         new SendEmailCommand({
           Destination: { ToAddresses: [booking.email] },
           Message: {
-            Body: { Text: { Data: `Join your session at ${baseUrl}${booking.roomUrl}` } },
+            Body: { Text: { Data: `Join your session at ${baseUrl}${booking.clientUrl}` } },
             Subject: { Data: 'Your session link' },
           },
           Source: process.env.EMAIL_FROM!,
@@ -30,7 +30,7 @@ export async function POST(req: NextRequest) {
       await sns.send(
         new PublishCommand({
           PhoneNumber: booking.phone,
-          Message: `Join your session at ${baseUrl}${booking.roomUrl}`,
+          Message: `Join your session at ${baseUrl}${booking.clientUrl}`,
         })
       );
     }

--- a/app/room/page.tsx
+++ b/app/room/page.tsx
@@ -68,9 +68,13 @@ function RoomContent() {
 
   return (
     <main className="container mx-auto p-4 space-y-4">
-      <div className="flex gap-4 w-full h-[80vh]">
-        <video ref={localVideoRef} className="flex-1 bg-black" autoPlay />
-        <video ref={remoteVideoRef} className="flex-1 bg-black" autoPlay />
+      <div className="relative w-full h-[80vh]">
+        <video ref={remoteVideoRef} className="w-full h-full bg-black" autoPlay />
+        <video
+          ref={localVideoRef}
+          className="absolute bottom-4 right-4 w-40 h-32 bg-black"
+          autoPlay
+        />
       </div>
     </main>
   );

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -16,7 +16,8 @@ export interface Booking {
   email: string;
   phone?: string;
   notes: string;
-  roomUrl?: string;
+  adminUrl?: string;
+  clientUrl?: string;
   status?: 'booked' | 'cancelled';
 }
 
@@ -61,18 +62,25 @@ export async function getBooking(id: string): Promise<Booking | undefined> {
   return res.Item as Booking | undefined;
 }
 
-export async function setRoomUrl(id: string, roomUrl: string): Promise<void> {
+export async function setRoomUrls(
+  id: string,
+  adminUrl: string,
+  clientUrl: string
+): Promise<void> {
   if (useBookingMemory) {
     const booking = bookings.find((b) => b.id === id);
-    if (booking) booking.roomUrl = roomUrl;
+    if (booking) {
+      booking.adminUrl = adminUrl;
+      booking.clientUrl = clientUrl;
+    }
     return;
   }
   await client!.send(
     new UpdateCommand({
       TableName: BOOKING_TABLE,
       Key: { id },
-      UpdateExpression: 'SET roomUrl = :url',
-      ExpressionAttributeValues: { ':url': roomUrl },
+      UpdateExpression: 'SET adminUrl = :a, clientUrl = :c',
+      ExpressionAttributeValues: { ':a': adminUrl, ':c': clientUrl },
     })
   );
 }

--- a/test/create-room.test.ts
+++ b/test/create-room.test.ts
@@ -15,8 +15,12 @@ describe('create-room API', () => {
     const res: any = await POST(req);
     assert.equal(res.status, 200);
     assert.equal(
-      res.data.url,
-      '/room?meetingId=MID&attendeeId=AID&token=TOKEN'
+      res.data.adminUrl,
+      '/room?meetingId=MID&attendeeId=AID1&token=TOKEN1'
+    );
+    assert.equal(
+      res.data.clientUrl,
+      '/room?meetingId=MID&attendeeId=AID2&token=TOKEN2'
     );
   });
 
@@ -32,17 +36,22 @@ describe('create-room API', () => {
     const res: any = await POST(req);
     assert.equal(res.status, 200);
     assert.equal(
-      res.data.url,
-      '/room?meetingId=MID&attendeeId=AID&token=TOKEN'
+      res.data.adminUrl,
+      '/room?meetingId=MID&attendeeId=AID1&token=TOKEN1'
+    );
+    assert.equal(
+      res.data.clientUrl,
+      '/room?meetingId=MID&attendeeId=AID2&token=TOKEN2'
     );
   });
 
   it('returns existing room url', async () => {
     const now = new Date();
-    bookings.push({ id: '3', date: now.toISOString().slice(0,10), time: now.toISOString().slice(11,16), name: 'C', email: 'c', notes: 'n', roomUrl: 'foo' });
+    bookings.push({ id: '3', date: now.toISOString().slice(0,10), time: now.toISOString().slice(11,16), name: 'C', email: 'c', notes: 'n', adminUrl: 'foo', clientUrl: 'bar' });
     const req = new NextRequest('http://test', { body: JSON.stringify({ id: '3' }) });
     const res: any = await POST(req);
     assert.equal(res.status, 200);
-    assert.equal(res.data.url, 'foo');
+    assert.equal(res.data.adminUrl, 'foo');
+    assert.equal(res.data.clientUrl, 'bar');
   });
 });

--- a/test/stubs/chime.js
+++ b/test/stubs/chime.js
@@ -4,7 +4,9 @@ class ChimeSDKMeetingsClient {
       return { Meeting: { MeetingId: 'MID' } };
     }
     if (cmd.constructor.name === 'CreateAttendeeCommand') {
-      return { Attendee: { AttendeeId: 'AID', JoinToken: 'TOKEN' } };
+      if (!this.count) this.count = 0;
+      this.count += 1;
+      return { Attendee: { AttendeeId: `AID${this.count}`, JoinToken: `TOKEN${this.count}` } };
     }
     if (cmd.constructor.name === 'GetMeetingCommand') {
       return {


### PR DESCRIPTION
## Summary
- create distinct join URLs for admin and client
- adjust Admin UI to work with new adminUrl field
- email/text client link using clientUrl
- overlay local video so both feeds show at once
- update meeting stub and tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684d25b9f5d8833083d105ef82ab7196