### PR TITLE
Add transcript view

### DIFF
--- a/app/admin/AdminClient.tsx
+++ b/app/admin/AdminClient.tsx
@@ -116,6 +116,11 @@ export default function AdminClient() {
                   <Button size="sm" variant="destructive" onClick={() => cancelBooking(b.id)}>
                     Cancel
                   </Button>
+                  {b.transcript && (
+                    <Button size="sm" onClick={() => router.push(`/admin/transcripts/${b.id}`)}>
+                      Transcript
+                    </Button>
+                  )}
                 </div>
               )}
             </Card>

--- a/app/admin/transcripts/[id]/page.tsx
+++ b/app/admin/transcripts/[id]/page.tsx
@@ -1,0 +1,24 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+
+interface Props { params: { id: string } }
+
+export default async function TranscriptPage({ params }: Props) {
+  const cookie = cookies().get('auth');
+  if (!cookie) {
+    redirect('/login');
+  }
+  const res = await fetch(`${process.env.SITE_URL || ''}/api/bookings/${params.id}/transcript`, { cache: 'no-store' });
+  if (!res.ok) {
+    return <p className="p-4 text-red-500">Transcript not found.</p>;
+  }
+  const data = await res.json();
+  return (
+    <main className="container mx-auto p-4">
+      <h1 className="text-xl font-semibold mb-4">Transcript</h1>
+      <pre className="whitespace-pre-wrap bg-gray-100 p-4 rounded">
+        {data.transcript || 'No transcript available.'}
+      </pre>
+    </main>
+  );
+}

--- a/app/api/bookings/[id]/start-transcription/route.ts
+++ b/app/api/bookings/[id]/start-transcription/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server';
+import { getBooking } from '../../../../../lib/data';
+import {
+  ChimeSDKMeetingsClient,
+  StartMeetingTranscriptionCommand,
+} from '@aws-sdk/client-chime-sdk-meetings';
+
+export async function POST(_: Request, { params }: { params: { id: string } }) {
+  const booking = await getBooking(params.id);
+  if (!booking || !booking.meetingId) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+  const client = new ChimeSDKMeetingsClient({});
+  try {
+    await client.send(
+      new StartMeetingTranscriptionCommand({
+        MeetingId: booking.meetingId,
+        TranscriptionConfiguration: {
+          EngineTranscribeSettings: {
+            LanguageCode: 'en-US',
+            Region: (process.env.AWS_REGION || 'us-east-1') as any,
+          },
+        },
+      })
+    );
+    return NextResponse.json({ ok: true });
+  } catch (err: any) {
+    console.error('Start transcription failed', err);
+    const message = err && typeof err === 'object' && 'message' in err ? err.message : 'Failed to start transcription';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/app/api/bookings/[id]/transcript/route.ts
+++ b/app/api/bookings/[id]/transcript/route.ts
@@ -1,0 +1,20 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { appendTranscript, getTranscript, setTranscript } from '../../../../../lib/data';
+
+export async function GET(_: NextRequest, { params }: { params: { id: string } }) {
+  const transcript = await getTranscript(params.id);
+  if (!transcript) {
+    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  }
+  return NextResponse.json({ transcript });
+}
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const { transcript, append } = await req.json();
+  if (append) {
+    await appendTranscript(params.id, transcript);
+  } else {
+    await setTranscript(params.id, transcript);
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/create-room/route.ts
+++ b/app/api/create-room/route.ts
@@ -43,15 +43,15 @@ export async function POST(req: NextRequest) {
       meetingRes.Meeting!.MeetingId!
     )}&attendeeId=${encodeURIComponent(adminRes.Attendee!.AttendeeId!)}&token=${encodeURIComponent(
       adminRes.Attendee!.JoinToken!
-    )}`;
+    )}&bookingId=${encodeURIComponent(id)}&role=admin`;
 
     const clientUrl = `/room?meetingId=${encodeURIComponent(
       meetingRes.Meeting!.MeetingId!
     )}&attendeeId=${encodeURIComponent(clientRes.Attendee!.AttendeeId!)}&token=${encodeURIComponent(
       clientRes.Attendee!.JoinToken!
-    )}`;
+    )}&bookingId=${encodeURIComponent(id)}&role=client`;
 
-    await setRoomUrls(id, adminUrl, clientUrl);
+    await setRoomUrls(id, adminUrl, clientUrl, meetingRes.Meeting!.MeetingId!);
     return NextResponse.json({ adminUrl, clientUrl });
   } catch (err: any) {
     console.error('Chime create meeting failed', err);

--- a/test/create-room.test.ts
+++ b/test/create-room.test.ts
@@ -16,12 +16,13 @@ describe('create-room API', () => {
     assert.equal(res.status, 200);
     assert.equal(
       res.data.adminUrl,
-      '/room?meetingId=MID&attendeeId=AID1&token=TOKEN1'
+      '/room?meetingId=MID&attendeeId=AID1&token=TOKEN1&bookingId=1&role=admin'
     );
     assert.equal(
       res.data.clientUrl,
-      '/room?meetingId=MID&attendeeId=AID2&token=TOKEN2'
+      '/room?meetingId=MID&attendeeId=AID2&token=TOKEN2&bookingId=1&role=client'
     );
+    assert.equal(bookings[0].meetingId, 'MID');
   });
 
   it('returns 404 for missing booking', async () => {
@@ -37,12 +38,13 @@ describe('create-room API', () => {
     assert.equal(res.status, 200);
     assert.equal(
       res.data.adminUrl,
-      '/room?meetingId=MID&attendeeId=AID1&token=TOKEN1'
+      '/room?meetingId=MID&attendeeId=AID1&token=TOKEN1&bookingId=2&role=admin'
     );
     assert.equal(
       res.data.clientUrl,
-      '/room?meetingId=MID&attendeeId=AID2&token=TOKEN2'
+      '/room?meetingId=MID&attendeeId=AID2&token=TOKEN2&bookingId=2&role=client'
     );
+    assert.equal(bookings[0].meetingId, 'MID');
   });
 
   it('returns existing room url', async () => {

--- a/test/stubs/chime.js
+++ b/test/stubs/chime.js
@@ -20,10 +20,15 @@ class ChimeSDKMeetingsClient {
         },
       };
     }
+    if (cmd.constructor.name === 'StartMeetingTranscriptionCommand') {
+      this.transcriptionStarted = true;
+      return {};
+    }
     return {};
   }
 }
 class CreateMeetingCommand { constructor() {} }
 class CreateAttendeeCommand { constructor() {} }
 class GetMeetingCommand { constructor() {} }
-module.exports = { ChimeSDKMeetingsClient, CreateMeetingCommand, CreateAttendeeCommand, GetMeetingCommand };
+class StartMeetingTranscriptionCommand { constructor() {} }
+module.exports = { ChimeSDKMeetingsClient, CreateMeetingCommand, CreateAttendeeCommand, GetMeetingCommand, StartMeetingTranscriptionCommand };

--- a/test/transcript.test.ts
+++ b/test/transcript.test.ts
@@ -1,0 +1,39 @@
+import { strict as assert } from 'assert';
+import { bookings } from '../lib/data';
+import { GET, POST } from '../app/api/bookings/[id]/transcript/route';
+import { POST as START } from '../app/api/bookings/[id]/start-transcription/route';
+import { NextRequest } from 'next/server';
+
+describe('transcript API', () => {
+  beforeEach(() => { bookings.length = 0; });
+
+  it('sets and retrieves transcript', async () => {
+    bookings.push({ id: '1', date: 'd', time: 't', name: 'A', email: 'e', notes: 'n' });
+    const postReq = new NextRequest('http://test', { body: JSON.stringify({ transcript: 'hello world' }) });
+    const postRes: any = await POST(postReq, { params: { id: '1' } });
+    assert.equal(postRes.status, 200);
+
+    const getRes: any = await GET(new NextRequest('http://test'), { params: { id: '1' } });
+    assert.equal(getRes.status, 200);
+    assert.equal(getRes.data.transcript, 'hello world');
+  });
+
+  it('appends transcript chunks', async () => {
+    bookings.push({ id: '2', date: 'd', time: 't', name: 'B', email: 'b', notes: 'n' });
+    await POST(new NextRequest('http://test', { body: JSON.stringify({ transcript: 'hello ' }) }), { params: { id: '2' } });
+    await POST(new NextRequest('http://test', { body: JSON.stringify({ transcript: 'world', append: true }) }), { params: { id: '2' } });
+    const res: any = await GET(new NextRequest('http://test'), { params: { id: '2' } });
+    assert.equal(res.data.transcript, 'hello world');
+  });
+
+  it('returns 404 for missing transcript', async () => {
+    const res: any = await GET(new NextRequest('http://test'), { params: { id: 'x' } });
+    assert.equal(res.status, 404);
+  });
+
+  it('starts meeting transcription', async () => {
+    bookings.push({ id: '5', date: 'd', time: 't', name: 'D', email: 'd', notes: 'n', meetingId: 'MID' });
+    const res: any = await START(new NextRequest('http://test'), { params: { id: '5' } });
+    assert.equal(res.status, 200);
+  });
+});


### PR DESCRIPTION
## Summary
- store transcripts with bookings
- expose transcript API endpoints
- display transcript link in admin dashboard
- add admin page to view a booking's transcript
- test transcript API
- store meetingId and trigger meeting transcription
- add role flag to meeting URLs and restrict transcription controls to admin

## Testing
- `pnpm install`
- `npx --yes mocha -r ts-node/register -r ./test/setup.js "test/**/*.test.ts" --reporter spec`


------
https://chatgpt.com/codex/tasks/task_e_684d3ec68fa883308627c62cd1e92b13