### PR TITLE
Add past bookings tab

### DIFF
--- a/app/admin/history/page.tsx
+++ b/app/admin/history/page.tsx
@@ -1,0 +1,11 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import AdminClient from '../AdminClient';
+
+export default function HistoryPage() {
+  const cookie = cookies().get('auth');
+  if (!cookie) {
+    redirect('/login');
+  }
+  return <AdminClient past />;
+}


### PR DESCRIPTION
## Summary
- add `past` optional flag to `AdminClient`
- filter bookings by current date and add nav buttons for Upcoming/Past
- add `/admin/history` route for past bookings

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684d4731b2cc8330bb1c8f9c5d205c90