### PR TITLE
Fix live transcript display

### DIFF
--- a/app/api/bookings/[id]/transcript/route.ts
+++ b/app/api/bookings/[id]/transcript/route.ts
@@ -1,10 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { appendTranscript, getTranscript, setTranscript } from '../../../../../lib/data';
 
-export async function GET(_: NextRequest, { params }: { params: { id: string } }) {
+export async function GET(
+  _: NextRequest,
+  { params }: { params: { id: string } }
+) {
   const transcript = await getTranscript(params.id);
+  // If transcription hasn't started yet return an empty string rather than 404
   if (!transcript) {
-    return NextResponse.json({ error: 'Not found' }, { status: 404 });
+    return NextResponse.json({ transcript: '' });
   }
   return NextResponse.json({ transcript });
 }

--- a/app/room/page.tsx
+++ b/app/room/page.tsx
@@ -228,7 +228,7 @@ function RoomContent() {
           <>
             {loading && <p className="text-center text-gray-600">Connecting to meeting...</p>}
             <div className="flex flex-col sm:flex-row gap-4 h-[75vh]">
-              <div className="w-full sm:w-1/3 max-h-64 sm:max-h-full rounded-2xl overflow-y-auto bg-neutral-900 shadow-lg p-2 text-sm whitespace-pre-wrap">
+              <div className="w-full sm:w-1/3 max-h-64 sm:max-h-full rounded-2xl overflow-y-auto bg-neutral-100 shadow-lg p-2 text-sm whitespace-pre-wrap">
                 {transcript
                   ? transcript
                   : transcriptionStarted

--- a/test/transcript.test.ts
+++ b/test/transcript.test.ts
@@ -26,9 +26,10 @@ describe('transcript API', () => {
     assert.equal(res.data.transcript, 'hello world');
   });
 
-  it('returns 404 for missing transcript', async () => {
+  it('returns empty transcript when none set', async () => {
     const res: any = await GET(new NextRequest('http://test'), { params: { id: 'x' } });
-    assert.equal(res.status, 404);
+    assert.equal(res.status, 200);
+    assert.equal(res.data.transcript, '');
   });
 
   it('starts meeting transcription', async () => {


### PR DESCRIPTION
## Summary
- return empty transcript rather than 404 when no transcript exists yet
- lighten transcript panel background so text is visible
- update tests for transcript API

## Testing
- `pnpm install`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684d83bdc20c8330a6f18379f08f4c7d